### PR TITLE
Fix issue with use of pteidlibj.dll, using SDK initSDK instead

### DIFF
--- a/citizen-card-reader-lib/src/main/kotlin/com/rmpt/citizencard/reader/peidlib/PteidlibLoader.kt
+++ b/citizen-card-reader-lib/src/main/kotlin/com/rmpt/citizencard/reader/peidlib/PteidlibLoader.kt
@@ -1,8 +1,7 @@
 package com.rmpt.citizencard.reader.peidlib
 
-import com.rmpt.citizencard.reader.peidlib.setup.PteidSetupFactory
 import mu.KotlinLogging
-import pt.gov.cartaodecidadao.PTEID_ReaderSet
+import pt.gov.cartaodecidadao.*;
 
 object PteidlibLoader {
 
@@ -13,10 +12,8 @@ object PteidlibLoader {
     fun load() {
         if (!firstLoad) throw RuntimeException("Pteid lib already loaded. Library should only be laoded once")
         firstLoad = false
-
         log.info { "Loading PTEID library...." }
-        val nativeLibPath = PteidSetupFactory.new().run()
-        System.load(nativeLibPath)
+        PTEID_ReaderSet.initSDK();
         log.info { "PTEID library has been loaded." }
     }
 


### PR DESCRIPTION
No meu pc não estava a funcionar. Devido a erro de que a dll era 32 e o meu pc 64. Na documentação do CC, vi que era recomendado utilizar o método initSDK. Compilei e funciona. 